### PR TITLE
Export the Name field in the Cursor struct

### DIFF
--- a/b2/b2.go
+++ b/b2/b2.go
@@ -284,7 +284,7 @@ func (o *Object) Delete(ctx context.Context) error {
 
 // Cursor is passed to ListObjects to return subsequent pages.
 type Cursor struct {
-	name string
+	Name string
 	id   string
 }
 
@@ -298,14 +298,14 @@ func (b *Bucket) ListObjects(ctx context.Context, count int, c *Cursor) ([]*Obje
 	if c == nil {
 		c = &Cursor{}
 	}
-	fs, name, id, err := b.b.listFileVersions(ctx, count, c.name, c.id)
+	fs, name, id, err := b.b.listFileVersions(ctx, count, c.Name, c.id)
 	if err != nil {
 		return nil, nil, err
 	}
 	var next *Cursor
 	if name != "" && id != "" {
 		next = &Cursor{
-			name: name,
+			Name: name,
 			id:   id,
 		}
 	}
@@ -330,14 +330,14 @@ func (b *Bucket) ListCurrentObjects(ctx context.Context, count int, c *Cursor) (
 	if c == nil {
 		c = &Cursor{}
 	}
-	fs, name, err := b.b.listFileNames(ctx, count, c.name)
+	fs, name, err := b.b.listFileNames(ctx, count, c.Name)
 	if err != nil {
 		return nil, nil, err
 	}
 	var next *Cursor
 	if name != "" {
 		next = &Cursor{
-			name: name,
+			Name: name,
 		}
 	}
 	var objects []*Object
@@ -368,7 +368,7 @@ func (o *Object) Hide(ctx context.Context) error {
 // of a given name, it will reveal the most recent.
 func (b *Bucket) Reveal(ctx context.Context, name string) error {
 	cur := &Cursor{
-		name: name,
+		Name: name,
 	}
 	objs, _, err := b.ListObjects(ctx, 1, cur)
 	if err != nil && err != io.EOF {

--- a/b2/writer.go
+++ b/b2/writer.go
@@ -224,7 +224,7 @@ func (w *Writer) getLargeFile() (beLargeFileInterface, error) {
 	var size int64
 	var fi beFileInterface
 	for {
-		cur := &Cursor{name: w.name}
+		cur := &Cursor{Name: w.name}
 		objs, _, err := w.o.b.ListObjects(w.ctx, 1, cur)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR changes the `Cursor` struct field name from `name` to `Name`.

This change allows packages implementing blazer to create a Cursor object and specify the Name value. For example: `cur := &b2.Cursor{Name: "prefix/"}`

This is useful for specifying the prefix search term in a list file name operation.

For example, this will pass "photos/" to the prefix parameter in  [b2_list_file_names](https://www.backblaze.com/b2/docs/b2_list_file_names.html):
```
cur := &b2.Cursor{Name: "photos/"}
objs, c, err := bucket.ListCurrentObjects(context, 100, cur)
```
