### PR TITLE
Added RO-Access to Name Attribute

### DIFF
--- a/b2/b2.go
+++ b/b2/b2.go
@@ -155,6 +155,11 @@ type Attrs struct {
 	Info            map[string]string // Save arbitrary metadata on upload, but limited to 10 keys.
 }
 
+// Name returns an object's name
+func (o *Object) Name() string {
+	return o.name
+}
+
 // Attrs returns an object's attributes.
 func (o *Object) Attrs(ctx context.Context) (*Attrs, error) {
 	if err := o.ensure(ctx); err != nil {


### PR DESCRIPTION
If quick paging through filenames using ListObjects and ListCurrentObjects, the current model requires the attributes to be requested from the Backblaze API.

However, the object already contains it's name, so this roundtrip is unnecessary. The function Object.Name() allows to quickly access the name without having to call back to the Backblaze API once per object, saving a couple hundred API calls in the process.