### PR TITLE
Add custom transport

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -43,6 +43,7 @@ import (
 )
 
 var (
+	// APIBase is the URL for the API endpoint.
 	APIBase = "https://api.backblazeb2.com"
 )
 

--- a/base/base.go
+++ b/base/base.go
@@ -45,6 +45,9 @@ import (
 var (
 	// APIBase is the URL for the API endpoint.
 	APIBase = "https://api.backblazeb2.com"
+
+	// Transport is the http.RoundTripper used to execute HTTP requests to the API.
+	Transport = http.DefaultTransport
 )
 
 type b2err struct {
@@ -232,7 +235,7 @@ type httpReply struct {
 func makeNetRequest(req *http.Request) <-chan httpReply {
 	ch := make(chan httpReply)
 	go func() {
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := Transport.RoundTrip(req)
 		ch <- httpReply{resp, err}
 		close(ch)
 	}()


### PR DESCRIPTION
For the sake of discussion (see #9), I've added a package level variable to configure the HTTP transport. I'd rather like to be able to configure a custom transport per `*b2.Client`, but that means adding another parameter to all functions in `base`.

Please let me know what you think!