### PR TITLE
Expose contentMd5 field in GetFileInfoResponse.

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -1018,6 +1018,7 @@ func (b *Bucket) ListFileNames(ctx context.Context, count int, continuation, pre
 			Info: &FileInfo{
 				Name:        f.Name,
 				SHA1:        f.SHA1,
+				MD5:         f.MD5,
 				Size:        f.Size,
 				ContentType: f.ContentType,
 				Info:        f.Info,
@@ -1061,6 +1062,7 @@ func (b *Bucket) ListFileVersions(ctx context.Context, count int, startName, sta
 			Info: &FileInfo{
 				Name:        f.Name,
 				SHA1:        f.SHA1,
+				MD5:         f.MD5,
 				Size:        f.Size,
 				ContentType: f.ContentType,
 				Info:        f.Info,
@@ -1199,6 +1201,7 @@ func (b *Bucket) HideFile(ctx context.Context, name string) (*File, error) {
 type FileInfo struct {
 	Name        string
 	SHA1        string
+	MD5         string
 	Size        int64
 	ContentType string
 	Info        map[string]string
@@ -1224,6 +1227,7 @@ func (f *File) GetFileInfo(ctx context.Context) (*FileInfo, error) {
 	f.Info = &FileInfo{
 		Name:        b2resp.Name,
 		SHA1:        b2resp.SHA1,
+		MD5:         b2resp.MD5,
 		Size:        b2resp.Size,
 		ContentType: b2resp.ContentType,
 		Info:        b2resp.Info,

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -211,6 +211,7 @@ type GetFileInfoResponse struct {
 	BucketID    string            `json:"bucketId,omitempty"`
 	Size        int64             `json:"contentLength,omitempty"`
 	SHA1        string            `json:"contentSha1,omitempty"`
+	MD5         string            `json:"contentMd5,omitempty"`
 	ContentType string            `json:"contentType,omitempty"`
 	Info        map[string]string `json:"fileInfo,omitempty"`
 	Action      string            `json:"action,omitempty"`


### PR DESCRIPTION
It's 2020 and we're adding an MD5 hash, you gotta be kidding me, right?
Technically yes, however the use case behind this is that AWS S3 uses
an MD5 hash as ETag for historical reasons. In order to ease working
with client libraries that rely on this (not officially deprecated)
behaviour when accessing B2 through an S3 compatibility layer such as
MinIO Gateway, it would be nice to expose the field.

Quoting the B2 docs:
> contentMd5 [optional]
> The MD5 of the bytes stored in the file as a 32-digit hex string.
> Not all files have an MD5 checksum, so this field is optional,
> and set to null for files that do not have one. Large files do not
> have MD5 checksums, and the value is null.

P.S. I'm not very familiar with this codebase, so I might have missed a spot.
I didn't see any tests using `contentSha1`, so I wasn't sure where to start. Please let me know if you have a suggestion :) 
I didn't adjust the `pyre` package because it doesn't appear to be used.
Compiling and using the library with this change from a patched MinIO version works well.
