### PR TITLE
Add .ID on b2.Object (can be used after uploads)

### DIFF
--- a/b2/b2.go
+++ b/b2/b2.go
@@ -438,6 +438,11 @@ func (o *Object) Name() string {
 	return o.name
 }
 
+// ID returns an object's id
+func (o *Object) ID() string {
+	return o.f.id()
+}
+
 // Attrs returns an object's attributes.
 func (o *Object) Attrs(ctx context.Context) (*Attrs, error) {
 	if err := o.ensure(ctx); err != nil {

--- a/b2/b2_test.go
+++ b/b2/b2_test.go
@@ -319,6 +319,7 @@ type testFile struct {
 	files map[string]string
 }
 
+func (t *testFile) id() string           { return t.n }
 func (t *testFile) name() string         { return t.n }
 func (t *testFile) size() int64          { return t.s }
 func (t *testFile) timestamp() time.Time { return t.t }

--- a/b2/backend.go
+++ b/b2/backend.go
@@ -77,6 +77,7 @@ type beURL struct {
 
 type beFileInterface interface {
 	name() string
+	id() string
 	size() int64
 	timestamp() time.Time
 	status() string
@@ -540,6 +541,10 @@ func (b *beFile) size() int64 {
 
 func (b *beFile) name() string {
 	return b.b2file.name()
+}
+
+func (b *beFile) id() string {
+	return b.b2file.id()
 }
 
 func (b *beFile) timestamp() time.Time {

--- a/b2/baseline.go
+++ b/b2/baseline.go
@@ -64,6 +64,7 @@ type b2URLInterface interface {
 
 type b2FileInterface interface {
 	name() string
+	id() string
 	size() int64
 	timestamp() time.Time
 	status() string
@@ -418,6 +419,10 @@ func (b *b2File) deleteFileVersion(ctx context.Context) error {
 
 func (b *b2File) name() string {
 	return b.b.Name
+}
+
+func (b *b2File) id() string {
+	return b.b.ID
 }
 
 func (b *b2File) size() int64 {


### PR DESCRIPTION
This commit includes a public ID field for for Object after uploads.

The ID is returning correctly after file upload (I did not need to implement the ID, just a shortcut the the data on the interfaces)

