### PR TITLE
Remove stray printf in Bucket.getObject

### DIFF
--- a/b2/b2.go
+++ b/b2/b2.go
@@ -620,7 +620,6 @@ func (discard) Write(p []byte) (int, error) {
 func (b *Bucket) getObject(ctx context.Context, name string) (*Object, error) {
 	fr, err := b.b.downloadFileByName(ctx, name, 0, 0, true)
 	if err != nil {
-		fmt.Printf("%v: %T\n", err, err)
 		return nil, err
 	}
 	io.Copy(discard{}, fr)


### PR DESCRIPTION
https://github.com/kurin/blazer/commit/3ad36f176f10c391369dd258d09ce187882f876e added a stray printf which results in unexpected output in case of non-existing files.
See https://github.com/restic/restic/issues/3750 for an example.